### PR TITLE
fix(learn): Use `MaxPrimaryTradeSkill` from config instead of `2`

### DIFF
--- a/src/ProfessionNPC.cpp
+++ b/src/ProfessionNPC.cpp
@@ -222,7 +222,7 @@ public:
         if (SkillCount > 0 && player->HasSkill(Skill))
             SkillCount--;
 
-        return SkillCount < 2;
+        return SkillCount < sWorld->getIntConfig(CONFIG_MAX_PRIMARY_TRADE_SKILL);
     }
 };
 


### PR DESCRIPTION
Use `MaxPrimaryTradeSkill` from config instead of `2` max profession count

The maximum number of profession is currently hard-coded.
We should instead use `MaxPrimaryTradeSkill` from the config.