### PR TITLE
fix: Spell IDs and feat: Enable/Disable each profession

### DIFF
--- a/conf/mod_npc_free_professions.conf.dist
+++ b/conf/mod_npc_free_professions.conf.dist
@@ -27,10 +27,23 @@ NpcFreeProfessions.Enable = 1
 NpcFreeProfessions.GivenCraftLevel = 450
 
 #
-#   NpcFreeProfessions.HideHerbalismSkinningAndMining
-#       Description: Hide Herbalism, Skinning, and Mining as they give low level players way too powerful bonuses (healing, crit, and stamina)
-#       Default:    0 - Disabled, default
-#                   1 - Enabled
+#   NpcFreeProfessions.Enable.EachProfession
+#       Description: Enable/Disable each profession
+#       Default:    1 - Enabled, default
+#                   0 - Disabled
 #
 
-NpcFreeProfessions.HideHerbalismSkinningAndMining = 0
+NpcFreeProfessions.Enable.Alchemy = 1
+NpcFreeProfessions.Enable.Blacksmithing = 1
+NpcFreeProfessions.Enable.Leatherworking = 1
+NpcFreeProfessions.Enable.Tailoring = 1
+NpcFreeProfessions.Enable.Engineering = 1
+NpcFreeProfessions.Enable.Enchanting = 1
+NpcFreeProfessions.Enable.Jewelcrafting = 1
+NpcFreeProfessions.Enable.Inscription = 1
+NpcFreeProfessions.Enable.Herbalism = 1
+NpcFreeProfessions.Enable.Skinning = 1
+NpcFreeProfessions.Enable.Mining = 1
+NpcFreeProfessions.Enable.Cooking = 1
+NpcFreeProfessions.Enable.FirstAid = 1
+NpcFreeProfessions.Enable.Fishing = 1

--- a/src/ProfessionNPC.cpp
+++ b/src/ProfessionNPC.cpp
@@ -7,7 +7,20 @@
 
 bool ModConfigEnable = 1;
 uint16 ModConfigGivenCraftLevel = 450;
-bool ModConfigHideHerbalismSkinningAndMining = 0;
+bool ModConfigEnableAlchemy = 1;
+bool ModConfigEnableBlacksmithing = 1;
+bool ModConfigEnableLeatherworking = 1;
+bool ModConfigEnableTailoring = 1;
+bool ModConfigEnableEngineering = 1;
+bool ModConfigEnableEnchanting = 1;
+bool ModConfigEnableJewelcrafting = 1;
+bool ModConfigEnableInscription = 1;
+bool ModConfigEnableHerbalism = 1;
+bool ModConfigEnableSkinning = 1;
+bool ModConfigEnableMining = 1;
+bool ModConfigEnableCooking = 1;
+bool ModConfigEnableFirstAid = 1;
+bool ModConfigEnableFishing = 1;
 
 class NpcFreeProfessionsConfig : public WorldScript
 {
@@ -23,7 +36,20 @@ public:
     {
         ModConfigEnable = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable", 1);
         ModConfigGivenCraftLevel = sConfigMgr->GetOption<uint16>("NpcFreeProfessions.GivenCraftLevel", 450);
-        ModConfigHideHerbalismSkinningAndMining = sConfigMgr->GetOption<bool>("NpcFreeProfessions.HideHerbalismSkinningAndMining", 0);
+        ModConfigEnableAlchemy = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Alchemy", 1);
+        ModConfigEnableBlacksmithing = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Blacksmithing", 1);
+        ModConfigEnableLeatherworking = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Leatherworking", 1);
+        ModConfigEnableTailoring = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Tailoring", 1);
+        ModConfigEnableEngineering = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Engineering", 1);
+        ModConfigEnableEnchanting = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Enchanting", 1);
+        ModConfigEnableJewelcrafting = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Jewelcrafting", 1);
+        ModConfigEnableInscription = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Inscription", 1);
+        ModConfigEnableHerbalism = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Herbalism", 1);
+        ModConfigEnableSkinning = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Skinning", 1);
+        ModConfigEnableMining = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Mining", 1);
+        ModConfigEnableCooking = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Cooking", 1);
+        ModConfigEnableFirstAid = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.FirstAid", 1);
+        ModConfigEnableFishing = sConfigMgr->GetOption<bool>("NpcFreeProfessions.Enable.Fishing", 1);
     }
 };
 
@@ -36,25 +62,48 @@ public:
     {
         if (ModConfigEnable)
         {
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Alchemy", GOSSIP_SENDER_MAIN, SKILL_ALCHEMY);
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Blacksmithing", GOSSIP_SENDER_MAIN, SKILL_BLACKSMITHING);
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Leatherworking", GOSSIP_SENDER_MAIN, SKILL_LEATHERWORKING);
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Tailoring", GOSSIP_SENDER_MAIN, SKILL_TAILORING);
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Engineering", GOSSIP_SENDER_MAIN, SKILL_ENGINEERING);
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Enchanting", GOSSIP_SENDER_MAIN, SKILL_ENCHANTING);
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Jewelcrafting", GOSSIP_SENDER_MAIN, SKILL_JEWELCRAFTING);
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Inscription", GOSSIP_SENDER_MAIN, SKILL_INSCRIPTION);
-
-            if (!ModConfigHideHerbalismSkinningAndMining){
+            if (ModConfigEnableAlchemy){
+                AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Alchemy", GOSSIP_SENDER_MAIN, SKILL_ALCHEMY);
+            }
+            if (ModConfigEnableBlacksmithing){
+                AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Blacksmithing", GOSSIP_SENDER_MAIN, SKILL_BLACKSMITHING);
+            }
+            if (ModConfigEnableLeatherworking){
+                AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Leatherworking", GOSSIP_SENDER_MAIN, SKILL_LEATHERWORKING);
+            }
+            if (ModConfigEnableTailoring){
+                AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Tailoring", GOSSIP_SENDER_MAIN, SKILL_TAILORING);
+            }
+            if (ModConfigEnableEngineering){
+                AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Engineering", GOSSIP_SENDER_MAIN, SKILL_ENGINEERING);
+            }
+            if (ModConfigEnableEnchanting){
+                AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Enchanting", GOSSIP_SENDER_MAIN, SKILL_ENCHANTING);
+            }
+            if (ModConfigEnableJewelcrafting){
+                AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Jewelcrafting", GOSSIP_SENDER_MAIN, SKILL_JEWELCRAFTING);
+            }
+            if (ModConfigEnableInscription){
+                AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Inscription", GOSSIP_SENDER_MAIN, SKILL_INSCRIPTION);
+            }
+            if (ModConfigEnableHerbalism){
                 AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Herbalism", GOSSIP_SENDER_MAIN, SKILL_HERBALISM);
+            }
+            if (ModConfigEnableSkinning){
                 AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Skinning", GOSSIP_SENDER_MAIN, SKILL_SKINNING);
+            }
+            if (ModConfigEnableMining){
                 AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Mining", GOSSIP_SENDER_MAIN, SKILL_MINING);
             }
-
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Cooking", GOSSIP_SENDER_MAIN, SKILL_COOKING);
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "First Aid", GOSSIP_SENDER_MAIN, SKILL_FIRST_AID);
-            AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Fishing", GOSSIP_SENDER_MAIN, SKILL_FISHING);
-
+            if (ModConfigEnableCooking){
+                AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Cooking", GOSSIP_SENDER_MAIN, SKILL_COOKING);
+            }
+            if (ModConfigEnableFirstAid){
+                AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "First Aid", GOSSIP_SENDER_MAIN, SKILL_FIRST_AID);
+            }
+            if (ModConfigEnableFishing){
+                AddGossipItemFor(player, GOSSIP_ICON_TRAINER, "Fishing", GOSSIP_SENDER_MAIN, SKILL_FISHING);
+            }
             SendGossipMenuFor(player, DEFAULT_GOSSIP_MESSAGE, creature);
         }
 


### PR DESCRIPTION
Changes Proposed:
1. Completed learnSpells for Cooking, First Aid, and Fishing by adding the non-Grand Master level spells (Apprentice to Master). Before the change, these lower level spells were still listed as available to learn at the profession trainers after they had been learnt from Kaylub.

Also, I'm not sure why there appear to be three Grand Master Fishing with different Spell IDs #64484, #65293, #51293. I've changed the Spell ID from the previous #65293 to #64484. But after testing all three, they seem to function identically anyway.

2. Added new configurations that allow players to enable/disable each profession as some players may want to disable some professions. For exmaple, Herbalism, Skinning, and Mining can give low level players way to powerful bonuses (healing, crit, and stamina) that completely trivialise leveling.

SOURCE:
https://www.wowhead.com/wotlk/spell=2550/cooking
https://www.wowhead.com/wotlk/spell=3102/cooking
https://www.wowhead.com/wotlk/spell=3413/cooking
https://www.wowhead.com/wotlk/spell=18260/cooking
https://www.wowhead.com/wotlk/spell=33359/cooking
https://www.wowhead.com/wotlk/spell=51296/cooking

https://www.wowhead.com/wotlk/spell=3273/first-aid
https://www.wowhead.com/wotlk/spell=3274/first-aid
https://www.wowhead.com/wotlk/spell=7924/first-aid
https://www.wowhead.com/wotlk/spell=10846/first-aid
https://www.wowhead.com/wotlk/spell=27028/first-aid
https://www.wowhead.com/wotlk/spell=45542/first-aid

https://www.wowhead.com/wotlk/spell=7620/fishing
https://www.wowhead.com/wotlk/spell=7731/fishing
https://www.wowhead.com/wotlk/spell=7732/fishing
https://www.wowhead.com/wotlk/spell=18248/fishing
https://www.wowhead.com/wotlk/spell=33095/fishing
https://www.wowhead.com/wotlk/spell=64484/grand-master-fishing
https://www.wowhead.com/wotlk/spell=65293/grand-master-fishing
https://www.wowhead.com/wotlk/spell=51293/grand-master-fishing